### PR TITLE
Fix typo

### DIFF
--- a/content/urlsearchparams-como-leer-la-query-string.md
+++ b/content/urlsearchparams-como-leer-la-query-string.md
@@ -41,7 +41,7 @@ params.get('precio') // null
 Además, **el objeto que nos devuelve es iterable**, por lo que podremos utilizar los diferentes métodos iterativos para poder acceder a todos los parámetros que tenemos en nuestra query.
 
 ```js
-for (let p of searchParams) {
+for (let p of params) {
   console.log(p);
 }
 


### PR DESCRIPTION
In your example you create the variable `params` to use `URLSearchParams`  and `queryString` as object, but then use the undefined variable `searchParams ` to iterate with a for loop.