### PR TITLE
Fix styles for Twitch logo

### DIFF
--- a/layouts/partials/icons/twitch.html
+++ b/layouts/partials/icons/twitch.html
@@ -1,1 +1,13 @@
-<svg x="0" y="0" viewBox="0 0 2400 2800" height="24" width="28" xml:space="preserve"><style>.st1{fill:#9146ff}</style><path fill="#fff" d="M2200 1300l-400 400h-400l-350 350v-350H600V200h1600z"/><g><path class="st1" d="M500 0L0 500v1800h600v500l500-500h400l900-900V0H500zm1700 1300l-400 400h-400l-350 350v-350H600V200h1600v1100z"/><path class="st1" d="M1700 550h200v600h-200zM1150 550h200v600h-200z"/></g></svg>
+<svg x="0" y="0" viewBox="0 0 2400 2800" height="24" width="28" xml:space="preserve">
+    <style>
+        .twitch-st1 {
+            fill: #9146ff
+        }
+    </style>
+    <path fill="#fff" d="M2200 1300l-400 400h-400l-350 350v-350H600V200h1600z" />
+    <g>
+        <path class="twitch-st1"
+            d="M500 0L0 500v1800h600v500l500-500h400l900-900V0H500zm1700 1300l-400 400h-400l-350 350v-350H600V200h1600v1100z" />
+        <path class="twitch-st1" d="M1700 550h200v600h-200zM1150 550h200v600h-200z" />
+    </g>
+</svg>


### PR DESCRIPTION
Fix Twitch logo styles that were overridden in the mentoring page