### PR TITLE
Add canonical url to layout

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -22,7 +22,12 @@
   <script src="{{ $tracking.Permalink }}" data-site="YZRWTFHZ" defer></script>
   
   <meta name="description" content="{{- .Description | default .Site.Params.Description -}}">
+
+  {{ if .Params.canonicalUrl }}
+  <link rel="canonical" href="{{ .Params.canonicalUrl }}">
+  {{ else }}
   <link rel="canonical" href="{{ .Permalink }}">
+  {{ end }}
 
   {{ partial "head/favicons.html" . }}
 


### PR DESCRIPTION
If `canonicalUrl` is found on the post, then it will be used for meta tag canonical.