### PR TITLE
Fix typo in youtube id

### DIFF
--- a/content/posts/5-consejos-desarrolladores-junior.md
+++ b/content/posts/5-consejos-desarrolladores-junior.md
@@ -8,7 +8,7 @@ tags:
 - me
 ---
 
-{{< youtube id="-yw7_3ysx1Q " >}}
+{{< youtube id="-yw7_3ysx1Q" >}}
 
 # 1️⃣ NO PUEDES SABERLO TODO
 


### PR DESCRIPTION
The youtube video id had an space at the end, so it was never going to load

![Id error](https://user-images.githubusercontent.com/98111143/164414831-2af7276a-b94a-42e8-82c1-bbb6bf43a270.jpg)
