### PR TITLE
Fix extra line break in some list items

### DIFF
--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -280,9 +280,8 @@ svg {
 }
 
 #article-content ul {
-  padding-left: 16px;
+  padding-left: 24px;
   padding-bottom: 16px;
-  list-style-position: inside;
 }
 
 #article-content li {

--- a/content/posts/como-funciona-el-operador-igualdad-simple-javascript.md
+++ b/content/posts/como-funciona-el-operador-igualdad-simple-javascript.md
@@ -41,7 +41,7 @@ La regla dice que en una comparación `x == y`, donde `x` e `y` son valores, dev
     * Si `x` es 0 e `y` es 0, independientemente de su signo, devolverá `true`.
     * En cualquier otro caso, será `false`
   * Si `x` es `String` entonces será `true` si `x` e `y` tienen la misma secuencia de carácteres (misma longitud y posición). Si no, será `false`.
-  * * Si `x` es `Boolean` entonces devolverá `true` si ambos son `true` o ambos son `false`. Si no, será `false`.
+  * Si `x` es `Boolean` entonces devolverá `true` si ambos son `true` o ambos son `false`. Si no, será `false`.
   * Si `x` e `y` están referenciando al mismo objeto será `true`, si no `false`. 
 * Si `x` es `null` e `y` es `undefined` será `true`. 
 * Si `y` es `undefined` e `y` es `null` será `true`. 


### PR DESCRIPTION
In some articles, list items are adding an extra line break when they start with **bold** text. Some examples can be found in the following pages:

https://midu.dev/metricas-web-performance
https://midu.dev/por-que-creo-que-microsoft-use-chromium-es-una-buena-noticia
https://midu.dev/centrar-elementos-css

This issue was related to a CSS change for `list-style-position` in `#article-content ul` and has been added by a [recent commit](https://github.com/midudev/midu.dev/commit/ddbcc621420aa669016976bdfa05b9010e9c8b56)