### PR TITLE
Fix typo

### DIFF
--- a/content/posts/malas-practicas-javascript.md
+++ b/content/posts/malas-practicas-javascript.md
@@ -49,7 +49,7 @@ console.log(name) // 'Midu'
 // ✅ Usando let y const
 const name = 'Miguel'
 if (name === 'Miguel') {
-  let name = 'Miguel'
+  let name = 'Midu'
 }
 console.log(name) // 'Miguel'
 ```


### PR DESCRIPTION
In the second code example the `let` variable is assigned with the same value as the `const` variable, this way the example makes no sense.

The `let` variable should be assigned with a different value to demonstrate the scopes of the variables are different.