### PR TITLE
fixed text overlaping in podcast details page

### DIFF
--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -855,7 +855,7 @@ twitter-widget {
 
 #hits {
   position: absolute;
-  z-index: 2;
+  z-index: 3;
 }
 
 .ais-SearchBox-input::-ms-clear,


### PR DESCRIPTION
CSS update to fix text overlapping

Previous style
![image](https://user-images.githubusercontent.com/14883509/196986474-a1f2769e-3f8b-42c0-999f-d1c8ab5b44a2.png)
Actual style
![image](https://user-images.githubusercontent.com/14883509/196986592-b53c5b3d-8bcc-40ee-8d89-ae844651ccf4.png)
