### PR TITLE
🎨 fix aside styles to make hover readable in white mode

### DIFF
--- a/layouts/partials/aside.html
+++ b/layouts/partials/aside.html
@@ -70,6 +70,10 @@
       }
 
       #aside #cursos a:hover {
+        background: #eee;
+      }
+
+      html[scheme='dark-mode'] #aside #cursos a:hover {
         background: var(--bgc, #000);
         color: #fff;
       }


### PR DESCRIPTION
Make this content readable just like the articles on the homepage for white mode
![imatge](https://user-images.githubusercontent.com/76450853/207592835-bac32102-109c-4ecc-b0bb-78ac1c45a8ab.png)
![imatge](https://user-images.githubusercontent.com/76450853/207593277-38018ec3-5177-4580-b4eb-34746e1db719.png)
