### PR TITLE
No closing of fenced code block. (Rust Tutorial)

### DIFF
--- a/content/posts/rust-para-desarrolladores-javascript.md
+++ b/content/posts/rust-para-desarrolladores-javascript.md
@@ -882,6 +882,7 @@ fn check_is_odd_or_even(number: i32) -> String {
     _ => "no es ni par ni impar".to_string(),
   }
 }
+```
 
 ## Bucles en Rust
 


### PR DESCRIPTION
The loop explanation was inside the markdown to mark rust code when it should be outside.