### PR TITLE
Fix TOC layer position issue with z-index

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -67,6 +67,7 @@
 <style>
   #TableOfContents-container {
     display: none;
+    z-index: 2;
   }
 
   @media (min-width: 1300px) {


### PR DESCRIPTION
When there is a footer absolute element (like twitter share button in the example), can not be clicked inside the table of contents (TOC).

![image](https://user-images.githubusercontent.com/20746840/213182379-00e98d09-62a6-4076-8db7-62ab8ad2d8d6.png)
