### PR TITLE
feat: darkmode improvements

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -48,30 +48,44 @@ function createYoutubeFrame (id) {
   )
 }
 
-function initScheme() {
-  const isBrowserSchemeDark = window.matchMedia(
-    '(prefers-color-scheme: dark)'
-  ).matches
+let schemeState = 'dark-mode'
 
-  let scheme = isBrowserSchemeDark ? 'dark-mode' : 'light-mode'
+const isDarkmodeScheme = window.matchMedia('(prefers-color-scheme: dark)')
 
-  if (localStorage.getItem('scheme')) {
-    scheme = localStorage.getItem('scheme')
-  }
-  document.documentElement.setAttribute('scheme', scheme)
+function toggleDarkMode(state) {
+  document.documentElement.setAttribute('scheme', state ? 'dark-mode' : 'light-mode')
+  schemeState = state ? 'dark-mode' : 'light-mode'
+
+  $('#emoticon-mode').setAttribute('title', state ? 'Activar modo claro (Alt+Shift D)' : 'Activar modo oscuro (Alt+Shift D)')
 }
-initScheme()
 
-$('#emoticon-mode').addEventListener('click', function (e) {
-  const scheme = document.documentElement.getAttribute('scheme')
-  const isLightMode = scheme === 'light-mode'
+function saveSchemeState(state) {
+  localStorage.setItem('scheme', state ? 'dark-mode' : 'light-mode')
+}
 
-  document.documentElement.setAttribute(
-    'scheme',
-    isLightMode ? 'dark-mode' : 'light-mode'
-  )
+toggleDarkMode(localStorage.getItem('scheme') === 'dark-mode' || isDarkmodeScheme.matches)
 
-  localStorage.setItem('scheme', isLightMode ? 'dark-mode' : 'light-mode')
+isDarkmodeScheme.addListener(e => {
+  toggleDarkMode(e.matches)
+  saveSchemeState(e.matches)
+})
+
+$('#emoticon-mode').addEventListener('click', () => {
+  schemeState = schemeState === 'light-mode' ? 'dark-mode' : 'light-mode'
+
+  toggleDarkMode(schemeState === 'dark-mode')
+  saveSchemeState(schemeState === 'dark-mode')
+})
+
+// Keyboard shortcut for toggle dark mode with (Alt+Shift D) or
+// (Option+Shift D) on MacOS
+window.addEventListener('keydown', e => {
+  if (e.altKey === true && e.shiftKey === true && e.key === 'D') {
+    schemeState = schemeState === 'light-mode' ? 'dark-mode' : 'light-mode'
+
+    toggleDarkMode(schemeState === 'dark-mode')
+    saveSchemeState(schemeState === 'dark-mode')
+  }
 })
 
 $$('.youtube-link').forEach(function (link) {

--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -944,7 +944,7 @@ html[scheme='dark-mode'] img#midudev-logo {
   content: url('/logo-dark.png') !important;
 }
 html[scheme='dark-mode'] button#emoticon-mode::after {
-  content: '🌚' !important;
+  content: '🌞' !important;
 }
 button#emoticon-mode {
   font-size: x-large;
@@ -956,7 +956,7 @@ button#emoticon-mode:hover {
   border: 1px solid #09f;
 }
 html[scheme='light-mode'] button#emoticon-mode::after {
-  content: '🌞' !important;
+  content: '🌚' !important;
 }
 html[scheme='dark-mode'] button#emoticon-mode:hover {
   background: var(--dark-color-hover);

--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -943,14 +943,23 @@ html[scheme='dark-mode'] h3 {
 html[scheme='dark-mode'] img#midudev-logo {
   content: url('/logo-dark.png') !important;
 }
-html[scheme='dark-mode'] a#emoticon-mode::after {
+html[scheme='dark-mode'] button#emoticon-mode::after {
   content: '🌚' !important;
 }
-a#emoticon-mode {
+button#emoticon-mode {
   font-size: x-large;
+  padding: 4px 11px;
+  border: 1px solid transparent;
 }
-html[scheme='light-mode'] a#emoticon-mode::after {
+button#emoticon-mode:hover {
+  border-radius: 6px;
+  border: 1px solid #09f;
+}
+html[scheme='light-mode'] button#emoticon-mode::after {
   content: '🌞' !important;
+}
+html[scheme='dark-mode'] button#emoticon-mode:hover {
+  background: var(--dark-color-hover);
 }
 html[scheme='dark-mode'] .ais-SearchBox-input {
   background-color: var(--dark-background);

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,6 +9,8 @@
 
   {{ partial "head/preconnects.html" . }}
 
+  {{ partial "head/darkmode.html" . }}
+
   {{ $css := resources.Get "styles/global.css" }}
   {{ $style := $css | resources.Minify }}
   <style>{{$style.Content | safeCSS}}</style>

--- a/layouts/partials/head/darkmode.html
+++ b/layouts/partials/head/darkmode.html
@@ -1,0 +1,9 @@
+<script>
+  if (localStorage.getItem('scheme') === 'dark-mode' || window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    document.documentElement.setAttribute('scheme', 'dark-mode')
+    localStorage.setItem('scheme', 'dark-mode')
+  } else {
+    document.documentElement.setAttribute('scheme', 'light-mode')
+    localStorage.setItem('scheme', 'light-mode')
+  }
+</script>

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -41,7 +41,7 @@
       </div>
     </div>
   </div>
-  <a rel="noopener nofollow" id="emoticon-mode"></a>
+  <button id="emoticon-mode" type="button"></button>
   <a href="https://twitch.tv/midudev" target="_blank" rel="noopener nofollow" aria-label='Sígueme en Twitch'>
     {{ partial "icons/twitch.html" }}
   </a>


### PR DESCRIPTION
- [x] fix FOUC (Flash of unstyled content) between views

This is caused by the late evaluation of the previous script for dark mode, so emulating the connection in 3G causes FOUC between some views.

See issue in action:

https://user-images.githubusercontent.com/38303370/213938006-acd0429b-3464-4a60-8ba6-71eec4ab4564.mp4

This is solved added an small inline script in head (darkmode.html). It evaluates whether the `scheme` key exists in localStorage or the user's preference in their OS configuration, adding the `scheme` attribute immediately in `<html>` tag and before downloading and parsing the CSS.

- [x] add keyboard shortcut for toggle dark mode scheme

Added the keyboard shortcut Alt+shift D (or Option+Shift D on Mac) to toggle theme schema.

https://user-images.githubusercontent.com/38303370/213940805-2887cafe-a3a9-40df-9094-c6ee4282a043.mp4

- [x] add system configuration listener

A system configuration listener that detect the user preference, for accessibility reasons.


https://user-images.githubusercontent.com/38303370/213938740-87edf82e-a571-49e4-9582-21da3c641428.mp4

- [x] update emoticons viewing

Show moon on light mode:
![light mode](https://user-images.githubusercontent.com/38303370/213944470-fb142678-94e8-4d44-9481-91757e0d690d.jpg)

Show sun on dark mode:
![dark mode](https://user-images.githubusercontent.com/38303370/213944471-16d0d01e-3791-4c8c-afd3-4d3b9658f692.jpg)
