### PR TITLE
[Fix] Overridden button background color

### DIFF
--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -347,7 +347,7 @@ svg {
 
 /** BUTTON **/
 .button {
-  background-color: #1890ff;
+  background-color: #1890ff !important;
   border-color: #1890ff;
   border-radius: 4px;
   border: 0;


### PR DESCRIPTION
In the newsletter page, the button's background color was being overridden by a transparent background rule.

Newsletter: [Link](https://midu.dev/newsletter/)

![Screenshot - Bug](https://github.com/midudev/midu.dev/assets/84233833/4b103e98-d778-4630-9ada-4785474e7526)
![Screenshot - Fix](https://github.com/midudev/midu.dev/assets/84233833/f0601123-4ae3-4cc1-a969-a45eef64c568)
