### PR TITLE
Bug en la funcion getSecondsDiff

### DIFF
--- a/content/posts/como-crear-un-time-ago-sin-dependencias-intl-relativeformat.md
+++ b/content/posts/como-crear-un-time-ago-sin-dependencias-intl-relativeformat.md
@@ -78,7 +78,8 @@ Para recuperar la fecha actual con ese timestamp podemos usar `Date.now()`. Vamo
 const getSecondsDiff = (timestamp) => {
   // restamos el tiempo actual al que le pasamos por parámetro
   // lo dividimos entre 1000 para quitar los milisegundos
-  return (Date.now() - timestamp) / 1000
+  // y retornamos el valor absoluto
+  return Math.abs((Date.now() - timestamp) / 1000)
 }
 ```
 
@@ -146,7 +147,7 @@ const DATE_UNITS = {
   second: 1
 }
 
-const getSecondsDiff = timestamp => (Date.now() - timestamp) / 1000
+const getSecondsDiff = timestamp => Math.abs((Date.now() - timestamp) / 1000)
 const getUnitAndValueDate = (secondsElapsed) => {
   for (const [unit, secondsInUnit] of Object.entries(DATE_UNITS)) {
     if (secondsElapsed >= secondsInUnit || unit === "second") {


### PR DESCRIPTION
Al llamar a la función `getTimeAgo` con el siguiente `timestamp: Wed Oct 11 2023 00:36:12 GMT-0600 (hora estándar central)`, se observó un problema en la función `getSecondsDiff`.

```js
const getSecondsDiff = timestamp => (Date.now() - timestamp) / 1000
```

Esta función retornaba un valor negativo, lo que afectaba los cálculos posteriores.

Solución Propuesta:

Para solucionar este problema, agregué la función `Math.abs` en la función `getSecondsDiff`. Esto garantiza que el resultado sea siempre positivo, lo cual es esencial para que los cálculos posteriores, como `getUnitAndValueDate` y `rtf.format`, funcionen de manera correcta.

```js
Math.abs((Date.now() - timestamp) / 1000)
```

Antes del cambio, la función `getSecondsDiff` devolvía: -12422.617 y el resultado de la función `getTimeAgo` era el siguiente: 'dentro de 12.423 segundos'.

Después del cambio, la función `getSecondsDiff` devuelve: 12422.617 y ahora el resultado de la función `getTimeAgo` es: 'hace 3 horas'.