### PR TITLE
Alineación y estilo arreglados para metadatos de artículos

### DIFF
--- a/layouts/partials/article-meta.html
+++ b/layouts/partials/article-meta.html
@@ -1,12 +1,14 @@
 {{ if (isset .Params "audio") }}
 {{ else }}
+<div class="article-meta" style="display: flex; align-items: center; gap: 10px;">
   <time itemprop="datePublished" datetime='{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}'>
     {{ .Date.Day }} {{ index $.Site.Data.months (printf "%d" .Date.Month) }} {{ .Date.Year }}
   </time>
    · 
   <span>{{.ReadingTime}} minutos de lectura</span>
   · 
-  <a target="_blank" rel="noopener nofollow" href='https://github.com/midudev/midu.dev/edit/master/content/posts/{{.File.LogicalName}}'>
+  <a target="_blank" rel="noopener nofollow" href='https://github.com/midudev/midu.dev/edit/master/content/posts/{{.File.LogicalName}}' style="display: inline-flex; align-items: center;">
     ¿Una errata? Edita el artículo {{ partial "icons/github.html" . }}
   </a>
+</div>
 {{ end }}


### PR DESCRIPTION
He ajustado el formato de los metadatos del artículo para mantener todo en línea y centrado con flexbox así arreglando el logo de GitHub el cual se descolocaba.

**Antes**
![imagen](https://github.com/midudev/midu.dev/assets/89773173/717e5055-4ea6-4eef-94d4-20292adf419c)

**Después**
![imagen](https://github.com/midudev/midu.dev/assets/89773173/9499b0f4-9dc2-4316-9bf3-af24be44cc04)
