### PR TITLE
Delete h2 color on the 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -20,7 +20,6 @@
     }
 
     #h2 {
-      color: #444;
       font-size:1.5rem;
       padding-top: 16px;
       padding-bottom: 32px;


### PR DESCRIPTION
Previously:
<img width="865" alt="image" src="https://github.com/midudev/midu.dev/assets/32883172/86e079fa-7a6e-4783-b5ae-5f8e589140f2">


Now:
<img width="832" alt="image" src="https://github.com/midudev/midu.dev/assets/32883172/85cf0763-4003-49d7-bee4-3b912595a033">

